### PR TITLE
Fix message reply modal bug

### DIFF
--- a/listeners/actions/message-actions.ts
+++ b/listeners/actions/message-actions.ts
@@ -1,4 +1,4 @@
-import type { AllMiddlewareArgs, SlackActionMiddlewareArgs, BlockAction } from '@slack/bolt';
+import type { AllMiddlewareArgs, BlockAction, SlackActionMiddlewareArgs } from '@slack/bolt';
 
 // Simplified handlers to be fully implemented later
 export const addReactionHandler = async ({
@@ -8,8 +8,23 @@ export const addReactionHandler = async ({
   client,
 }: AllMiddlewareArgs & SlackActionMiddlewareArgs<BlockAction>) => {
   await ack();
-  logger.info('Add reaction action triggered');
-  // Implementation will be added once we fix TypeScript issues
+  try {
+    const action = body.actions?.[0];
+    if (!action || !('value' in action)) {
+      logger.error('Missing action value for add reaction');
+      return;
+    }
+
+    const { channel, messageTs } = JSON.parse(action.value as string);
+    await client.reactions.add({
+      channel,
+      timestamp: messageTs,
+      name: 'thumbsup',
+    });
+    logger.info('Reaction added successfully');
+  } catch (error) {
+    logger.error('Error adding reaction:', error);
+  }
 };
 
 export const replyToMessageHandler = async ({
@@ -19,6 +34,41 @@ export const replyToMessageHandler = async ({
   client,
 }: AllMiddlewareArgs & SlackActionMiddlewareArgs<BlockAction>) => {
   await ack();
-  logger.info('Reply to message action triggered');
-  // Implementation will be added once we fix TypeScript issues
-}; 
+  try {
+    const action = body.actions?.[0];
+    if (!action || !('value' in action)) {
+      logger.error('Missing action value for reply to message');
+      return;
+    }
+
+    const { channel, messageTs } = JSON.parse(action.value as string);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: {
+        type: 'modal',
+        callback_id: 'message_reply_view',
+        private_metadata: JSON.stringify({ channel, threadTs: messageTs }),
+        title: { type: 'plain_text', text: 'Reply to Message' },
+        submit: { type: 'plain_text', text: 'Send' },
+        close: { type: 'plain_text', text: 'Cancel' },
+        blocks: [
+          {
+            type: 'input',
+            block_id: 'message_block',
+            element: {
+              type: 'plain_text_input',
+              action_id: 'message_input',
+              multiline: true,
+            },
+            label: { type: 'plain_text', text: 'Reply' },
+          },
+        ],
+      },
+    });
+
+    logger.info('Opened reply modal');
+  } catch (error) {
+    logger.error('Error opening reply modal:', error);
+  }
+};

--- a/listeners/views/message-reply-view.ts
+++ b/listeners/views/message-reply-view.ts
@@ -1,15 +1,15 @@
-import { SlackViewMiddlewareArgs, Middleware, ViewSubmitAction } from "@slack/bolt";
+import type { Middleware, SlackViewMiddlewareArgs, ViewSubmitAction } from '@slack/bolt';
 
 /**
  * Handler for the message reply modal submission
  * This gets triggered when a user submits the message reply modal
  */
-export const messageReplyViewCallback: Middleware<SlackViewMiddlewareArgs<ViewSubmitAction>> = async ({ 
-  ack, 
-  view, 
-  client, 
-  body, 
-  logger 
+export const messageReplyViewCallback: Middleware<SlackViewMiddlewareArgs<ViewSubmitAction>> = async ({
+  ack,
+  view,
+  client,
+  body,
+  logger,
 }) => {
   try {
     // Acknowledge the view submission
@@ -17,8 +17,11 @@ export const messageReplyViewCallback: Middleware<SlackViewMiddlewareArgs<ViewSu
     
     // Extract the values from the view state
     const messageText = view.state.values.message_block.message_input.value;
-    const channelId = view.private_metadata;
-    const threadTs = body.view.callback_id.split('_')[2]; // Assuming callback_id format: 'message_reply_THREAD_TS'
+
+    // `private_metadata` stores channel and thread information as JSON
+    const metadata = JSON.parse(view.private_metadata || '{}');
+    const channelId = metadata.channel;
+    const threadTs = metadata.threadTs;
     
     // Log the submission details
     logger.info('Message reply view submitted', {
@@ -51,7 +54,9 @@ export const messageReplyViewCallback: Middleware<SlackViewMiddlewareArgs<ViewSu
   } catch (error) {
     logger.error('Error handling message reply view submission', {
       error: error instanceof Error ? error.message : String(error),
-      viewId: view.id
+      viewId: view.id,
     });
   }
-}; 
+};
+
+export default messageReplyViewCallback;


### PR DESCRIPTION
## Summary
- implement addReactionHandler and replyToMessageHandler
- parse thread and channel info from modal metadata

## Testing
- `npm run test` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68577e5a356c8326b9237c8bbf65ad22